### PR TITLE
Bootstrap empty Postgres on first app start for Portainer deploys.

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -224,6 +224,10 @@ Never commit `.env` files to version control. Use Docker secrets or external sec
 2. Check DATABASE_URL format
 3. Verify network connectivity between containers
 
+**`relation "families" does not exist` on startup (Portainer / pre-built image):**
+1. Pull the latest `raddadengineer/mintsprout:latest` image and redeploy — the app bootstraps an empty database on first start.
+2. If the database was partially initialized, stop the stack, wipe `MINTSPROUT_POSTGRES_DIR`, and redeploy fresh.
+
 ### Reset Everything
 
 > **Warning:** `docker compose down` no longer removes data by default — data lives in `MINTSPROUT_POSTGRES_DIR`. To wipe the database, stop Compose and delete that folder after backing up. Run `./scripts/backup-db.sh manual` first if you need to keep family data.

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ RUN adduser --system --uid 1001 mintsprout
 
 # Copy built application
 COPY --from=builder --chown=mintsprout:nodejs /app/dist ./dist
+COPY --chown=mintsprout:nodejs init-db.sql ./init-db.sql
 COPY --from=builder --chown=mintsprout:nodejs /app/package*.json ./
 COPY --from=deps --chown=mintsprout:nodejs /app/node_modules ./node_modules
 

--- a/README.md
+++ b/README.md
@@ -271,6 +271,8 @@ docker exec -it mintsprout-app npm run passwords:reset
 
 To deploy from Portainer without building locally, use [`docker-compose.portainer.yml`](docker-compose.portainer.yml) — it pulls `raddadengineer/mintsprout:latest` instead of building. Set the same environment variables in the stack editor (`JWT_SECRET`, `POSTGRES_PASSWORD`, `ALLOWED_ORIGINS`, `MINTSPROUT_*_DIR` paths, plus optional Sprout/kiosk vars). Mount `MINTSPROUT_BACKUPS_DIR` on the app container for on-disk scheduled backups.
 
+No host-mounted `init-db.sql` is required — the app applies the base schema automatically on first start when Postgres is empty. To reset from scratch, stop the stack and wipe `MINTSPROUT_POSTGRES_DIR`, then redeploy.
+
 **Important:** Portainer will not pick up code fixes until the Hub image is rebuilt and pushed. After pulling new code, rebuild/push the image (below), then in Portainer use **Pull and redeploy** on the stack.
 
 Rebuild and push the image after code changes:

--- a/server/base-schema.ts
+++ b/server/base-schema.ts
@@ -1,0 +1,50 @@
+import fs from "fs/promises";
+import path from "path";
+import { sql } from "drizzle-orm";
+import { db, pool, runSql } from "./db";
+
+const INIT_DB_SQL_PATH = path.join(process.cwd(), "init-db.sql");
+
+async function familiesTableExists(): Promise<boolean> {
+  if (pool) {
+    const result = await pool.query(
+      "SELECT to_regclass('public.families') AS rel",
+    );
+    return result.rows[0]?.rel != null;
+  }
+
+  const result = await db.execute(
+    sql`SELECT to_regclass('public.families') AS rel`,
+  );
+  const rows = Array.isArray(result)
+    ? result
+    : ((result as { rows?: { rel: string | null }[] }).rows ?? []);
+  return rows[0]?.rel != null;
+}
+
+/** Apply init-db.sql when Postgres has no base tables (e.g. Portainer without init mount). */
+export async function ensureBaseSchema(): Promise<void> {
+  if (await familiesTableExists()) {
+    return;
+  }
+
+  const initSql = await fs.readFile(INIT_DB_SQL_PATH, "utf8");
+
+  if (pool) {
+    const client = await pool.connect();
+    try {
+      await client.query("BEGIN");
+      await client.query(initSql);
+      await client.query("COMMIT");
+      console.log("✅ Base schema applied from init-db.sql");
+    } catch (err) {
+      await client.query("ROLLBACK");
+      throw err;
+    } finally {
+      client.release();
+    }
+  } else {
+    await runSql(initSql);
+    console.log("✅ Base schema applied from init-db.sql");
+  }
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -2,6 +2,7 @@ import express, { type Request, Response, NextFunction } from "express";
 import { registerRoutes } from "./routes";
 import { log } from "./log";
 import { serveStatic } from "./serve-static";
+import { ensureBaseSchema } from "./base-schema";
 import { initializeDatabase } from "./db-init";
 import { runMigrations, listFamilyIds } from "./migrations";
 import { storage } from "./storage";
@@ -37,6 +38,7 @@ app.use((req, res, next) => {
   // Initialize database if using PostgreSQL (production or when DATABASE_URL is set)
   if (process.env.NODE_ENV === 'production' || process.env.DATABASE_URL) {
     try {
+      await ensureBaseSchema();
       await runMigrations();
       await initializeDatabase();
       const { ensureCatalogLibrary } = await import("./catalog-seed");


### PR DESCRIPTION
Portainer stacks lack the init-db.sql mount, so fresh databases had no base tables before migrations ran.